### PR TITLE
Improve coding challenge verdict messaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.env
 /.devshell
 result
+/.idea/

--- a/challenges/src/endpoints/coding_challenges/submissions.rs
+++ b/challenges/src/endpoints/coding_challenges/submissions.rs
@@ -18,7 +18,9 @@ use poem::web::Data;
 use poem_ext::{db::DbTxn, response, responses::ErrorResponse};
 use poem_openapi::{param::Path, payload::Json, OpenApi};
 use sandkasten_client::{schemas::environments::Environment, SandkastenClient};
-use schemas::challenges::coding_challenges::{QueueStatus, Submission, SubmissionContent};
+use schemas::challenges::coding_challenges::{
+    CheckResult, QueueStatus, RunSummary, Submission, SubmissionContent,
+};
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, DatabaseConnection, DatabaseTransaction, DbErr, EntityTrait,
     ModelTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
@@ -37,6 +39,7 @@ use crate::{
             deduct_hearts, get_subtask, get_user_subtask, send_task_rewards, update_user_subtask,
             SendTaskRewardsError, UserSubtaskExt,
         },
+        verdict_message::{build_message, VerdictMessageContext},
     },
 };
 
@@ -48,6 +51,25 @@ pub struct Api {
     pub judge_lock: Arc<Semaphore>,
     pub reward_lock: Arc<KeyRwLock<(Uuid, Uuid)>>,
     pub queue_positions: Arc<RwLock<QueuePositions>>,
+}
+
+fn attach_verdict_message(result: &mut CheckResult<RunSummary>, limits: Option<(u64, u64)>) {
+    let (time_limit_ms, memory_limit_mb) = limits
+        .map(|(time, mem)| (Some(time), Some(mem)))
+        .unwrap_or((None, None));
+
+    result.message = build_message(VerdictMessageContext {
+        verdict: result.verdict,
+        reason: result.reason.as_deref(),
+        compile_status: result.compile.as_ref().map(|r| r.status),
+        compile_stderr: result.compile.as_ref().map(|r| r.stderr.as_str()),
+        run_status: result.run.as_ref().map(|r| r.status),
+        run_stderr: result.run.as_ref().map(|r| r.stderr.as_str()),
+        run_time_ms: result.run.as_ref().map(|r| r.resource_usage.time),
+        run_memory_kib: result.run.as_ref().map(|r| r.resource_usage.memory),
+        time_limit_ms,
+        memory_limit_mb,
+    });
 }
 
 #[OpenApi(tag = "Tags::CodingChallenges")]
@@ -96,7 +118,14 @@ impl Api {
                 .into_iter()
                 .map(|(submission, result)| {
                     let position = queue_positions.position(submission.id);
-                    Submission::from(&submission, result.map(Into::into), position)
+                    let mut result = result.map(Into::into);
+                    if let Some(ref mut res) = result {
+                        attach_verdict_message(
+                            res,
+                            Some((cc.time_limit as u64, cc.memory_limit as u64)),
+                        );
+                    }
+                    Submission::from(&submission, result, position)
                 })
                 .collect(),
         )

--- a/challenges/src/main.rs
+++ b/challenges/src/main.rs
@@ -75,6 +75,12 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
+    info!("Running executor smoke checks");
+    match crate::services::judge::smoke_test_java(&sandkasten).await {
+        Ok(_) => info!("Java executor smoke test succeeded"),
+        Err(err) => warn!("Java executor smoke test failed: {err:?}"),
+    }
+
     let jwt_secret = JwtSecret::try_from(config.jwt_secret.as_str())?;
     let services = Services::from_config(
         jwt_secret.clone(),

--- a/challenges/src/services/judge.rs
+++ b/challenges/src/services/judge.rs
@@ -1,10 +1,11 @@
+use anyhow::{bail, Context};
 use entity::sea_orm_active_enums::ChallengesVerdict;
 use fnct::{format::JsonFormatter, key};
 use lib::{Cache, CacheError};
 use sandkasten_client::{
     schemas::{
         programs::{
-            BuildRequest, BuildRunError, BuildRunRequest, BuildRunResult, File, LimitsOpt,
+            BuildRequest, BuildRunError, BuildRunRequest, BuildRunResult, EnvVar, File, LimitsOpt,
             MainFile, RunRequest, RunResult,
         },
         ErrorResponse,
@@ -16,8 +17,17 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 
+use super::verdict_message::{build_message, VerdictMessageContext};
+
 pub const EVALUATOR_TEMPLATE: &str = include_str!("../../assets/evaluator/template.py");
 pub const EVALUATOR_LIBRARY: &str = include_str!("../../assets/evaluator/lib.py");
+const JAVA_SMOKE_TEST: &str = r#"
+class Main {
+    public static void main(String[] args) {
+        System.out.println("ok");
+    }
+}
+"#;
 
 pub struct Judge<'a> {
     pub sandkasten: &'a SandkastenClient,
@@ -159,15 +169,29 @@ impl Judge<'_> {
         let code = match prepare_result.code {
             Some(code) => code,
             None => {
+                let reason = prepare_result.reason;
                 return Ok(CheckResult {
                     verdict: ChallengesVerdict::PreCheckFailed,
-                    reason: Some(prepare_result.reason),
+                    reason: Some(reason.clone()),
                     compile: None,
                     run: None,
-                })
+                    message: build_message(VerdictMessageContext {
+                        verdict: ChallengesVerdict::PreCheckFailed,
+                        reason: Some(reason.as_str()),
+                        compile_status: None,
+                        compile_stderr: None,
+                        run_status: None,
+                        run_stderr: None,
+                        run_time_ms: None,
+                        run_memory_kib: None,
+                        time_limit_ms: time_limit,
+                        memory_limit_mb: memory_limit,
+                    }),
+                });
             }
         };
 
+        let runtime_env = java_env_vars(environment, memory_limit);
         let output = match self
             .sandkasten
             .build_and_run(&BuildRunRequest {
@@ -177,10 +201,12 @@ impl Judge<'_> {
                         content: code,
                         ..Default::default()
                     },
+                    env_vars: runtime_env.clone(),
                     ..Default::default()
                 },
                 run: RunRequest {
                     stdin: Some(input.input.clone()),
+                    env_vars: runtime_env,
                     run_limits: LimitsOpt {
                         time: time_limit.map(|x| x / 1000 + 1),
                         memory: memory_limit,
@@ -196,12 +222,27 @@ impl Judge<'_> {
                     ErrorResponse::Inner(BuildRunError::EnvironmentNotFound) => {
                         Err(Error::EnvironmentNotFound)
                     }
-                    ErrorResponse::Inner(BuildRunError::CompileError(result)) => Ok(CheckResult {
-                        verdict: ChallengesVerdict::CompilationError,
-                        reason: None,
-                        compile: Some(result),
-                        run: None,
-                    }),
+                    ErrorResponse::Inner(BuildRunError::CompileError(result)) => {
+                        let message = build_message(VerdictMessageContext {
+                            verdict: ChallengesVerdict::CompilationError,
+                            reason: None,
+                            compile_status: Some(result.status),
+                            compile_stderr: Some(&result.stderr),
+                            run_status: None,
+                            run_stderr: None,
+                            run_time_ms: None,
+                            run_memory_kib: None,
+                            time_limit_ms: time_limit,
+                            memory_limit_mb: memory_limit,
+                        });
+                        Ok(CheckResult {
+                            verdict: ChallengesVerdict::CompilationError,
+                            reason: None,
+                            compile: Some(result),
+                            run: None,
+                            message,
+                        })
+                    }
                     err => Err(Error::Sandkasten(SandkastenError::ErrorResponse(Box::new(
                         err,
                     )))),
@@ -220,11 +261,24 @@ impl Judge<'_> {
             _ if output.run.stdout.is_empty() => Some(ChallengesVerdict::NoOutput),
             _ => None,
         } {
+            let message = build_message(VerdictMessageContext {
+                verdict,
+                reason: None,
+                compile_status: output.build.as_ref().map(|r| r.status),
+                compile_stderr: output.build.as_ref().map(|r| r.stderr.as_str()),
+                run_status: Some(output.run.status),
+                run_stderr: Some(output.run.stderr.as_str()),
+                run_time_ms: Some(output.run.resource_usage.time),
+                run_memory_kib: Some(output.run.resource_usage.memory),
+                time_limit_ms: time_limit,
+                memory_limit_mb: memory_limit,
+            });
             return Ok(CheckResult {
                 verdict,
                 reason: None,
                 compile: output.build,
                 run: Some(output.run),
+                message,
             });
         }
         let result = self
@@ -236,12 +290,68 @@ impl Judge<'_> {
                 },
             )
             .await?;
+        let verdict = result.verdict;
+        let reason = result.reason;
+        let message = build_message(VerdictMessageContext {
+            verdict,
+            reason: reason.as_deref(),
+            compile_status: output.build.as_ref().map(|r| r.status),
+            compile_stderr: output.build.as_ref().map(|r| r.stderr.as_str()),
+            run_status: Some(output.run.status),
+            run_stderr: Some(output.run.stderr.as_str()),
+            run_time_ms: Some(output.run.resource_usage.time),
+            run_memory_kib: Some(output.run.resource_usage.memory),
+            time_limit_ms: time_limit,
+            memory_limit_mb: memory_limit,
+        });
         Ok(CheckResult {
-            verdict: result.verdict,
-            reason: result.reason,
+            verdict,
+            reason,
             compile: output.build,
             run: Some(output.run),
+            message,
         })
+    }
+}
+
+fn java_env_vars(environment: &str, memory_limit_mb: Option<u64>) -> Vec<EnvVar> {
+    let env = environment.to_ascii_lowercase();
+    if env.starts_with("java") {
+        let mut env_vars = Vec::new();
+
+        let heap_settings = memory_limit_mb.and_then(|limit| {
+            if limit < 64 {
+                None
+            } else {
+                let headroom = limit.saturating_sub(16);
+                let suggested = ((limit as f64) * 0.6).round() as u64;
+                let xmx = suggested.min(headroom).max(32);
+                let xms = (xmx / 2).max(16);
+                Some((xms, xmx))
+            }
+        });
+
+        let tool_options = match heap_settings {
+            Some((xms, xmx)) => format!(
+                "-Xms{}m -Xmx{}m -Xss256k -XX:ThreadStackSize=256 -XX:+UseSerialGC",
+                xms, xmx
+            ),
+            None => "-Xss256k -XX:ThreadStackSize=256 -XX:+UseSerialGC".into(),
+        };
+
+        env_vars.push(EnvVar {
+            name: "JAVA_TOOL_OPTIONS".into(),
+            value: tool_options,
+        });
+
+        env_vars.push(EnvVar {
+            name: "MALLOC_ARENA_MAX".into(),
+            value: "2".into(),
+        });
+
+        env_vars
+    } else {
+        Vec::new()
     }
 }
 
@@ -255,6 +365,39 @@ pub async fn get_executor_config(
         })
         .await??
         .into())
+}
+
+pub async fn smoke_test_java(sandkasten: &SandkastenClient) -> anyhow::Result<()> {
+    let env_vars = java_env_vars("java", Some(256));
+    let result = sandkasten
+        .build_and_run(&BuildRunRequest {
+            build: BuildRequest {
+                environment: "java".into(),
+                main_file: MainFile {
+                    name: Some("Main.java".into()),
+                    content: JAVA_SMOKE_TEST.trim().into(),
+                    ..Default::default()
+                },
+                env_vars: env_vars.clone(),
+                ..Default::default()
+            },
+            run: RunRequest {
+                env_vars,
+                ..Default::default()
+            },
+        })
+        .await
+        .context("java smoke test execution failed")?;
+
+    if result.run.status != 0 {
+        bail!(
+            "java smoke test exited with status {} and stderr: {}",
+            result.run.status,
+            result.run.stderr
+        );
+    }
+
+    Ok(())
 }
 
 #[derive(Debug, Error)]

--- a/challenges/src/services/mod.rs
+++ b/challenges/src/services/mod.rs
@@ -3,3 +3,4 @@ pub mod judge;
 pub mod leaderboard;
 pub mod subtasks;
 pub mod tasks;
+pub mod verdict_message;

--- a/challenges/src/services/verdict_message.rs
+++ b/challenges/src/services/verdict_message.rs
@@ -1,0 +1,177 @@
+use std::collections::BTreeMap;
+
+use entity::sea_orm_active_enums::ChallengesVerdict;
+use schemas::challenges::coding_challenges::VerdictMessage;
+
+/// Context required to build a human friendly verdict message.
+pub struct VerdictMessageContext<'a> {
+    pub verdict: ChallengesVerdict,
+    pub reason: Option<&'a str>,
+    pub compile_status: Option<i32>,
+    pub compile_stderr: Option<&'a str>,
+    pub run_status: Option<i32>,
+    pub run_stderr: Option<&'a str>,
+    pub run_time_ms: Option<u64>,
+    pub run_memory_kib: Option<u64>,
+    pub time_limit_ms: Option<u64>,
+    pub memory_limit_mb: Option<u64>,
+}
+
+pub fn build_message(ctx: VerdictMessageContext<'_>) -> Option<VerdictMessage> {
+    use ChallengesVerdict::*;
+
+    let title_key = title_key(&ctx.verdict);
+    let mut params = BTreeMap::new();
+    let mut detail_candidates: Vec<&str> = Vec::new();
+
+    if let Some(reason) = ctx.reason {
+        detail_candidates.push(reason);
+    }
+
+    let body_key: Option<&'static str> = match ctx.verdict {
+        Ok => Some("VerdictHint.OK"),
+        TimeLimitExceeded => {
+            if let Some(actual) = ctx.run_time_ms {
+                params.insert("actual_ms".into(), actual.to_string());
+                params.insert("actual_seconds".into(), format_secs(actual));
+            } else {
+                params.insert("actual_ms".into(), "—".into());
+                params.insert("actual_seconds".into(), "—".into());
+            }
+            if let Some(limit) = ctx.time_limit_ms {
+                params.insert("limit_ms".into(), limit.to_string());
+                params.insert("limit_seconds".into(), format_secs(limit));
+            } else {
+                params.insert("limit_ms".into(), "—".into());
+                params.insert("limit_seconds".into(), "—".into());
+            }
+            if let Some(stderr) = ctx.run_stderr {
+                detail_candidates.push(stderr);
+            }
+            Some("VerdictHint.TIME_LIMIT_EXCEEDED")
+        }
+        MemoryLimitExceeded => {
+            if let Some(actual) = ctx.run_memory_kib {
+                params.insert("actual_kib".into(), actual.to_string());
+                params.insert("actual_mib".into(), format_mib(actual));
+            } else {
+                params.insert("actual_kib".into(), "—".into());
+                params.insert("actual_mib".into(), "—".into());
+            }
+            if let Some(limit) = ctx.memory_limit_mb {
+                params.insert("limit_mib".into(), limit.to_string());
+            } else {
+                params.insert("limit_mib".into(), "—".into());
+            }
+            if let Some(stderr) = ctx.run_stderr {
+                detail_candidates.push(stderr);
+            }
+            Some("VerdictHint.MEMORY_LIMIT_EXCEEDED")
+        }
+        CompilationError => {
+            if let Some(status) = ctx.compile_status {
+                params.insert("exit_code".into(), status.to_string());
+            } else {
+                params.insert("exit_code".into(), "?".into());
+            }
+            if let Some(stderr) = ctx.compile_stderr {
+                detail_candidates.push(stderr);
+            }
+            Some("VerdictHint.COMPILATION_ERROR")
+        }
+        RuntimeError => {
+            if let Some(status) = ctx.run_status {
+                params.insert("exit_code".into(), status.to_string());
+            } else {
+                params.insert("exit_code".into(), "?".into());
+            }
+            if let Some(stderr) = ctx.run_stderr {
+                detail_candidates.push(stderr);
+            }
+            Some("VerdictHint.RUNTIME_ERROR")
+        }
+        NoOutput => {
+            if let Some(stderr) = ctx.run_stderr {
+                detail_candidates.push(stderr);
+            }
+            if !params.contains_key("actual_seconds") {
+                params.insert("actual_seconds".into(), "—".into());
+            }
+            Some("VerdictHint.NO_OUTPUT")
+        }
+        WrongAnswer => Some("VerdictHint.WRONG_ANSWER"),
+        InvalidOutputFormat => {
+            if let Some(stderr) = ctx.run_stderr {
+                detail_candidates.push(stderr);
+            }
+            Some("VerdictHint.INVALID_OUTPUT_FORMAT")
+        }
+        PreCheckFailed => Some("VerdictHint.PRE_CHECK_FAILED"),
+    };
+
+    if matches!(
+        ctx.verdict,
+        WrongAnswer | PreCheckFailed | InvalidOutputFormat
+    ) && detail_candidates.is_empty()
+    {
+        if let Some(stderr) = ctx.run_stderr {
+            detail_candidates.push(stderr);
+        }
+        if let Some(stderr) = ctx.compile_stderr {
+            detail_candidates.push(stderr);
+        }
+    }
+
+    let detail = detail_candidates
+        .into_iter()
+        .filter_map(sanitize_detail)
+        .next();
+
+    Some(VerdictMessage {
+        title_key: title_key.into(),
+        body_key: body_key.map(|key| key.to_string()),
+        body_params: (!params.is_empty()).then_some(params),
+        detail,
+    })
+}
+
+fn title_key(verdict: &ChallengesVerdict) -> &'static str {
+    use ChallengesVerdict::*;
+    match verdict {
+        CompilationError => "Error.Verdict.COMPILATION_ERROR",
+        InvalidOutputFormat => "Error.Verdict.INVALID_OUTPUT_FORMAT",
+        MemoryLimitExceeded => "Error.Verdict.MEMORY_LIMIT_EXCEEDED",
+        NoOutput => "Error.Verdict.NO_OUTPUT",
+        Ok => "Error.Verdict.OK",
+        PreCheckFailed => "Error.Verdict.PRE_CHECK_FAILED",
+        RuntimeError => "Error.Verdict.RUNTIME_ERROR",
+        TimeLimitExceeded => "Error.Verdict.TIME_LIMIT_EXCEEDED",
+        WrongAnswer => "Error.Verdict.WRONG_ANSWER",
+    }
+}
+
+fn sanitize_detail(raw: &str) -> Option<String> {
+    let cleaned: Vec<_> = raw
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .filter(|line| !line.starts_with("/nix/store"))
+        .filter(|line| !line.contains("sandkasten"))
+        .filter(|line| !line.contains("nix/store"))
+        .take(3)
+        .map(String::from)
+        .collect();
+    if cleaned.is_empty() {
+        None
+    } else {
+        Some(cleaned.join("\n"))
+    }
+}
+
+fn format_secs(ms: u64) -> String {
+    format!("{:.2}", (ms as f64) / 1000.0)
+}
+
+fn format_mib(kib: u64) -> String {
+    format!("{:.2}", (kib as f64) / 1024.0)
+}

--- a/schemas/src/challenges/coding_challenges.rs
+++ b/schemas/src/challenges/coding_challenges.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use chrono::{DateTime, Utc};
 use entity::{
     challenges_coding_challenge_result, challenges_coding_challenge_submissions,
@@ -186,6 +188,8 @@ pub struct CheckResult<T: Send + Sync + Type + ParseFromJSON + ToJSON> {
     pub reason: Option<String>,
     pub compile: Option<T>,
     pub run: Option<T>,
+    #[oai(skip_serializing_if_is_none)]
+    pub message: Option<VerdictMessage>,
 }
 
 #[derive(Debug, Clone, Object)]
@@ -194,6 +198,21 @@ pub struct ExecutorConfig {
     pub time_limit: u64,
     /// The maximum `memory_limit` in megabytes.
     pub memory_limit: u64,
+}
+
+#[derive(Debug, Clone, Object, Serialize, Deserialize)]
+pub struct VerdictMessage {
+    /// Translation key for the localized verdict headline.
+    pub title_key: String,
+    /// Optional translation key for additional descriptive text.
+    #[oai(skip_serializing_if_is_none)]
+    pub body_key: Option<String>,
+    /// Optional translation parameters for the body text.
+    #[oai(skip_serializing_if_is_none)]
+    pub body_params: Option<BTreeMap<String, String>>,
+    /// Optional sanitized technical description for power users.
+    #[oai(skip_serializing_if_is_none)]
+    pub detail: Option<String>,
 }
 
 impl CodingChallengeSummary {
@@ -239,6 +258,7 @@ impl From<CheckResult<RunResult>> for CheckResult<RunSummary> {
             reason: value.reason,
             compile: value.compile.map(Into::into),
             run: value.run.map(Into::into),
+            message: value.message,
         }
     }
 }
@@ -288,6 +308,7 @@ impl From<challenges_coding_challenge_result::Model> for CheckResult<RunSummary>
                 value.run_time,
                 value.run_memory,
             ),
+            message: None,
         }
     }
 }


### PR DESCRIPTION
## Summary
- add structured verdict metadata for coding challenge submissions
- introduce verdict message builder with sanitized details and locale keys
- adjust Java executor configuration to respect challenge memory limits and add smoke test

## Testing
- cargo check -p challenges